### PR TITLE
Upgrade project for Android Studio 3.x

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '27.0.1'
+    compileSdkVersion 28
+    buildToolsVersion '28.0.3'
     defaultConfig {
         applicationId 'org.tensorflow.demo'
         minSdkVersion 21
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName '1.0'
 
@@ -28,5 +28,5 @@ android {
 }
 
 dependencies {
-    compile 'org.tensorflow:tensorflow-android:1.4.0'
+    implementation 'org.tensorflow:tensorflow-android:1.4.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.0'
+        classpath 'com.android.tools.build:gradle:3.2.1' // gradle-3.3.0 is not supported yet. gradle-3.2.1 works well
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl = https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
Tested under:
- Android Studio 3.2
- Android SDK 28 (buildToolsVersion=28.0.3)
- Android NDK r19
- gradle-4.10.1-all.zip and "com.android.tools.build:gradle-3.2.1"

Fixed issues:
- Because Android NDK r19 removes MIPS toolchain support while gradle 3.0.0 didn't, you would got error a message saying that "mips\*-\* toolchain ot found"